### PR TITLE
feat: Add offline mode - use local affected-packages.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ shai-hulud-scanner --scan-workflows
 
 # Verbose output
 shai-hulud-scanner --verbose
+
+# Offline mode (does not use affected-packages from github)
+shai-hulud-scanner --offline
 ```
 
 ### CLI Reference

--- a/src/cli.py
+++ b/src/cli.py
@@ -82,7 +82,12 @@ def main():
         action='store_true',
         help='Display overview of Shai-Hulud worm'
     )
-    
+    parser.add_argument(
+        '--offline',
+        action='store_true',
+        help='Use local affected-packages.json without fetching from remote'
+    )
+
     args = parser.parse_args()
     
     # Handle overview option
@@ -125,7 +130,7 @@ def main():
     
     try:
         # Load badlist
-        bad_packages = get_badlist()
+        bad_packages = get_badlist(offline=args.offline)
         
         # Run scanners
         dep_results = scan_dependencies(directory, bad_packages, is_json)


### PR DESCRIPTION
Hello, 

I wanted to be able to check my changes to `affected-packages.json` locally. 
So I refactored a bit the get_badlist logic and adding a load_local_badlist usable via a CLI switch. 

It could be useful for other use cases, so feel free to review the changes 🙂